### PR TITLE
Minimum Viable Product #2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy API to Azure Functions
+name: Deploy API to Azure App Service
 
 on:
     push:
@@ -11,7 +11,7 @@ on:
           required: true
 
 env:
-  AZURE_FUNCTIONAPP_NAME: 'func-pv-test'
+  AZURE_APP_SERVICE_NAME: 'app-pvapi-test'
   API_PROJECT: 'ProgressVisualiserApi'
   API_TEST_PROJECT: 'ProgressVisualiserApi.Tests'
   DOTNET_VERSION: '8.0.x'          
@@ -19,8 +19,6 @@ env:
 jobs:
   build-and-deploy:
     runs-on: windows-latest
-    permissions:
-        id-token: write # Required for OIDC
     steps:
     - name: 'Checkout repo'
       uses: actions/checkout@v4
@@ -40,18 +38,13 @@ jobs:
       run: dotnet test
       working-directory: ${{ env.API_TEST_PROJECT }}
 
-    # OIDC authentication with an Azure Managed Identity
-    # They play nicely with Azure Functions, not yet with Azure SQL deployment
     - name: 'Log in to Azure with AZ CLI'
       uses: azure/login@v2
       with:
-        client-id: ${{ vars.AZURE_CLIENT_ID }}
-        tenant-id: ${{ vars.AZURE_TENANT_ID }}
-        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+        creds: ${{ secrets.AZURE_CREDENTIALS }} 
 
-    - name: 'Deploy API to Azure Functions'
-      uses: Azure/functions-action@v1
-      id: deploy-to-function-app
+    - name: 'Deploy API to Azure App Service'
+      uses: azure/webapps-deploy@v2
       with:
-        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        app-name: ${{ env.AZURE_APP_SERVICE_NAME }}
         package: '${{ env.API_PROJECT }}/output'

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 An API to support basic CRUD functionality and data processing for the [progress-visualiser-frontend](https://github.com/yalshaeyr/progress-visualiser-frontend) repo
 
 ## Deployment
-Follow the instructions listed in the [Azure/functions-action repo](https://github.com/Azure/functions-action?tab=readme-ov-file#use-oidc-recommended)
+Follow the instructions listed in the [azure/webapps-deploy repo](https://github.com/Azure/webapps-deploy?tab=readme-ov-file#configure-deployment-credentials-1)


### PR DESCRIPTION
Reworking the pipeline to deploy to App Service instead of Functions. Did not configure the project to run with Functions and completely forgot. No harm, no foul. This means I had to forego OIDC because it's not compatible with `azure/webapps-deploy` v2. Using Service Principal authentication.